### PR TITLE
Post-merge documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added shareable preview links limitation to known issues
 - Documented that python-substack library hasn't been updated in 2+ years
 
+### Infrastructure
+- Fixed CI/CD pipeline - all tests now pass in GitHub Actions
+- Added unit and integration tests to version control (fixed .gitignore)
+- Fixed code formatting and linting issues across entire codebase
+
 ### Known Issues
 - Image rendering shows markdown syntax instead of rendered images
 - Subscriber count may show 0 even with subscribers (API limitation)  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## 📋 Requirements
 
-- Python 3.9 or higher
+- Python 3.10 or higher
 - Substack account credentials:
     - Email and password (recommended)
     - OR session token and user ID


### PR DESCRIPTION
## Summary
Small documentation fixes that were made after the main v1.0.3 PR was merged:

- Fixed Python version requirement from 3.9 to 3.10+ in README (matches the badge)
- Added Infrastructure section to CHANGELOG documenting CI/CD fixes

These changes complete the v1.0.3 documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)