### PR TITLE
Fix MCP initialization capabilities to enable tool discovery

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -820,7 +820,7 @@ class SubstackMCPServer:
                 InitializationOptions(
                     server_name="substack-mcp-plus",
                     server_version="1.0.3",
-                    capabilities={},
+                    capabilities={"tools": {}},
                 ),
             )
             logger.info("Server run completed")


### PR DESCRIPTION
Without specifying tools in the capabilities dict, MCP clients fail to discover and
   call tools exposed by the server. Changing capabilities={} to capabilities={"tools": {}}
  fixes this.