### PR TITLE
Fix paragraph handler losing inline formatting (bold, italic, links)

### DIFF
--- a/src/handlers/post_handler.py
+++ b/src/handlers/post_handler.py
@@ -1287,9 +1287,8 @@ class PostHandler:
             content = block.get("content")
 
             if block_type == "paragraph":
-                # Extract text and add as single paragraph
-                text_content = self._extract_text_from_content(content)
-                post.paragraph(text_content)
+                # Pass content list directly to preserve inline formatting (bold, italic, links)
+                post.paragraph(content)
 
             elif block_type in [
                 "heading-one",


### PR DESCRIPTION
## Problem

`MarkdownConverter` correctly parses markdown into a rich AST, e.g.:

```json
{"type": "text", "content": "bold text", "marks": [{"type": "strong"}]}
```

But `_add_blocks_to_post` immediately discards this by calling `_extract_text_from_content()`, which re-serializes the AST back to a plain string. The result is that `**bold text**` is stored as a literal string in Substack — asterisks and all — instead of bold text.

## Fix

Pass the `content` list directly to `post.paragraph()`. The underlying `Post` class already supports rich content lists natively, so no other changes are needed.

## Impact

Inline formatting in paragraph text — **bold**, *italic*, and links — now renders correctly in Substack instead of showing literal markdown syntax.